### PR TITLE
feat: add group support for financial assets

### DIFF
--- a/src/app/dashboard/simulator/page.tsx
+++ b/src/app/dashboard/simulator/page.tsx
@@ -4,12 +4,12 @@ import FinancialAssetsChart from "@/components/FinancialAssetsChart";
 import { useAssetManagement } from "@/hooks/useAssetManagement";
 
 export default function SimulatorPage() {
-  const { financialAssets } = useAssetManagement();
+  const { assets } = useAssetManagement();
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-6">
       {/* 資産状況チャート */}
-      <FinancialAssetsChart assets={financialAssets} />
+      <FinancialAssetsChart assets={assets} />
     </div>
   );
 }

--- a/src/components/FinancialAssetsChart.tsx
+++ b/src/components/FinancialAssetsChart.tsx
@@ -11,14 +11,14 @@ import {
   Tooltip,
   Legend,
 } from "recharts";
-import { FinancialAssets } from "./FinancialAssetsForm";
 import { useFinancialSimulation } from "@/hooks/useFinancialSimulation";
 import { useGroupManagement } from "@/hooks/useGroupManagement";
 import { useIncomeManagement } from "@/hooks/useIncomeManagement";
 import { useExpenseManagement } from "@/hooks/useExpenseManagement";
+import { GroupedAsset } from "@/domains/group/types";
 
 interface FinancialAssetsChartProps {
-  assets: FinancialAssets;
+  assets: GroupedAsset[];
 }
 
 const COLORS = {
@@ -141,8 +141,12 @@ export default function FinancialAssetsChart({
                 fill={COLORS.deposits}
                 name="資産"
               />
-              {assets.assets
-                .filter((asset) => asset.returnRate > 0)
+              {assets
+                .filter(
+                  (asset) =>
+                    asset.returnRate > 0 &&
+                    activeGroupIds.includes(asset.groupId)
+                )
                 .map((asset, index) => (
                   <Bar
                     key={asset.id}
@@ -163,24 +167,27 @@ export default function FinancialAssetsChart({
                     name={income.name}
                   />
                 ))}
-              {assets.assets.map((asset) => {
-                const hasWithdrawalOptions =
-                  asset.withdrawalOptions && asset.withdrawalOptions.length > 0;
-                if (!hasWithdrawalOptions) return null;
+              {assets
+                .filter((asset) => activeGroupIds.includes(asset.groupId))
+                .map((asset) => {
+                  const hasWithdrawalOptions =
+                    asset.withdrawalOptions &&
+                    asset.withdrawalOptions.length > 0;
+                  if (!hasWithdrawalOptions) return null;
 
-                return (
-                  <Bar
-                    key={`sellback_income_${asset.id}`}
-                    dataKey={`sellback_income_${asset.id}`}
-                    stackId="b"
-                    fill={asset.color}
-                    name={`${
-                      asset.name || `資産 #${assets.assets.indexOf(asset) + 1}`
-                    } 売却益`}
-                    opacity={0.8}
-                  />
-                );
-              })}
+                  return (
+                    <Bar
+                      key={`sellback_income_${asset.id}`}
+                      dataKey={`sellback_income_${asset.id}`}
+                      stackId="b"
+                      fill={asset.color}
+                      name={`${
+                        asset.name || `資産 #${assets.indexOf(asset) + 1}`
+                      } 売却益`}
+                      opacity={0.8}
+                    />
+                  );
+                })}
               {expenses
                 .filter((expense) => activeGroupIds.includes(expense.groupId))
                 .map((expense) => (
@@ -192,25 +199,27 @@ export default function FinancialAssetsChart({
                     name={expense.name}
                   />
                 ))}
-              {assets.assets.map((asset) => {
-                const hasContributionOptions =
-                  asset.contributionOptions &&
-                  asset.contributionOptions.length > 0;
-                if (!hasContributionOptions) return null;
+              {assets
+                .filter((asset) => activeGroupIds.includes(asset.groupId))
+                .map((asset) => {
+                  const hasContributionOptions =
+                    asset.contributionOptions &&
+                    asset.contributionOptions.length > 0;
+                  if (!hasContributionOptions) return null;
 
-                return (
-                  <Bar
-                    key={`investment_expense_${asset.id}`}
-                    dataKey={`investment_expense_${asset.id}`}
-                    stackId="c"
-                    fill={asset.color}
-                    name={`${
-                      asset.name || `資産 #${assets.assets.indexOf(asset) + 1}`
-                    } 積立`}
-                    opacity={0.7}
-                  />
-                );
-              })}
+                  return (
+                    <Bar
+                      key={`investment_expense_${asset.id}`}
+                      dataKey={`investment_expense_${asset.id}`}
+                      stackId="c"
+                      fill={asset.color}
+                      name={`${
+                        asset.name || `資産 #${assets.indexOf(asset) + 1}`
+                      } 積立`}
+                      opacity={0.7}
+                    />
+                  );
+                })}
             </BarChart>
           </ResponsiveContainer>
         </div>

--- a/src/domains/group/types.ts
+++ b/src/domains/group/types.ts
@@ -31,4 +31,42 @@ export interface GroupedExpense {
   color: string;
 }
 
+/**
+ * グループに所属する金融資産
+ */
+export interface GroupedAsset {
+  id: string;
+  groupId: string;
+  name: string;
+  returnRate: number;
+  color: string;
+  baseAmount: number;
+  contributionOptions: ContributionOption[];
+  withdrawalOptions: WithdrawalOption[];
+}
+
+/**
+ * 積立オプション
+ */
+export interface ContributionOption {
+  id: string;
+  startYear: number;
+  startMonth: number;
+  endYear: number;
+  endMonth: number;
+  monthlyAmount: number;
+}
+
+/**
+ * 引き出しオプション
+ */
+export interface WithdrawalOption {
+  id: string;
+  startYear: number;
+  startMonth: number;
+  endYear: number;
+  endMonth: number;
+  monthlyAmount: number;
+}
+
 import { Cycle } from "@/domains/shared/Cycle";

--- a/src/domains/simulation/financialSimulation.ts
+++ b/src/domains/simulation/financialSimulation.ts
@@ -1,5 +1,8 @@
-import { FinancialAssets } from "@/components/FinancialAssetsForm";
-import { GroupedExpense, GroupedIncome } from "@/domains/group/types";
+import {
+  GroupedExpense,
+  GroupedIncome,
+  GroupedAsset,
+} from "@/domains/group/types";
 import { createCalculator } from "@/domains/shared/createCalculator";
 import { CalculatorSource } from "@/domains/shared/CalculatorSource";
 import { createSimulator } from "@/domains/simulation";
@@ -119,7 +122,7 @@ function convertToChartData(
  * @param activeGroupIds アクティブなグループIDのリスト（指定時はフィルタリング実行）
  */
 export function runFinancialSimulation(
-  assets: FinancialAssets,
+  assets: GroupedAsset[],
   expenses: GroupedExpense[],
   incomes: GroupedIncome[],
   simulationYears: number,
@@ -133,6 +136,10 @@ export function runFinancialSimulation(
   const filteredExpenses = activeGroupIds
     ? expenses.filter((expense) => activeGroupIds.includes(expense.groupId))
     : expenses;
+
+  const filteredAssets = activeGroupIds
+    ? assets.filter((asset) => activeGroupIds.includes(asset.groupId))
+    : assets;
 
   // 統合されたCalculatorインスタンスを作成
   const unifiedCalculator = createCalculator<CalculatorSource>();
@@ -148,7 +155,7 @@ export function runFinancialSimulation(
   });
 
   // すべての資産の初期額を合計（現金を含む）
-  const totalInitialAmount = assets.assets.reduce(
+  const totalInitialAmount = filteredAssets.reduce(
     (sum, asset) => sum + asset.baseAmount,
     0
   );

--- a/src/hooks/useAssetManagement.tsx
+++ b/src/hooks/useAssetManagement.tsx
@@ -1,23 +1,33 @@
 import { useCallback } from "react";
 import { useSimulation } from "@/contexts/SimulationContext";
-import { FinancialAssets } from "@/components/FinancialAssetsForm";
+import { GroupedAsset } from "@/domains/group/types";
 import { SIMULATION_ACTION_TYPES } from "@/types/simulation";
 
 export function useAssetManagement() {
   const { state, dispatch } = useSimulation();
 
-  const setFinancialAssets = useCallback(
-    (assets: FinancialAssets) => {
+  const upsertAssets = useCallback(
+    (groupId: string, assets: GroupedAsset[]) => {
       dispatch({
-        type: SIMULATION_ACTION_TYPES.SET_FINANCIAL_ASSETS,
-        payload: assets,
+        type: SIMULATION_ACTION_TYPES.UPSERT_ASSETS,
+        payload: { groupId, assets },
       });
     },
     [dispatch]
   );
 
+  const getAssetsByGroupId = useCallback(
+    (groupId: string) => {
+      return state.currentData.financialAssets.filter(
+        (asset) => asset.groupId === groupId
+      );
+    },
+    [state.currentData.financialAssets]
+  );
+
   return {
-    financialAssets: state.currentData.financialAssets,
-    setFinancialAssets,
+    assets: state.currentData.financialAssets,
+    upsertAssets,
+    getAssetsByGroupId,
   };
 }

--- a/src/hooks/useFinancialSimulation.test.ts
+++ b/src/hooks/useFinancialSimulation.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { runFinancialSimulation } from "@/domains/simulation/financialSimulation";
-import { FinancialAssets } from "@/components/FinancialAssetsForm";
-import { GroupedIncome, GroupedExpense } from "@/domains/group/types";
+import {
+  GroupedIncome,
+  GroupedExpense,
+  GroupedAsset,
+} from "@/domains/group/types";
 import { Cycle } from "@/domains/shared/Cycle";
 
 // Helper function to create a monthly cycle
@@ -15,19 +18,18 @@ function createMonthlyCycle(amount: number, startMonthIndex: number): Cycle {
 }
 
 describe("runFinancialSimulation", () => {
-  const defaultAssets: FinancialAssets = {
-    assets: [
-      {
-        id: "1",
-        name: "現金",
-        baseAmount: 1000000,
-        returnRate: 0,
-        color: "#3B82F6",
-        contributionOptions: [],
-        withdrawalOptions: [],
-      },
-    ],
-  };
+  const defaultAssets: GroupedAsset[] = [
+    {
+      id: "1",
+      groupId: "group1",
+      name: "現金",
+      baseAmount: 1000000,
+      returnRate: 0,
+      color: "#3B82F6",
+      contributionOptions: [],
+      withdrawalOptions: [],
+    },
+  ];
 
   it("初期資産のみの場合、資産額が変わらないこと", () => {
     const result = runFinancialSimulation(defaultAssets, [], [], 5);

--- a/src/hooks/useFinancialSimulation.tsx
+++ b/src/hooks/useFinancialSimulation.tsx
@@ -1,12 +1,15 @@
 "use client";
 
 import { useMemo } from "react";
-import { FinancialAssets } from "@/components/FinancialAssetsForm";
-import { GroupedExpense, GroupedIncome } from "@/domains/group/types";
+import {
+  GroupedExpense,
+  GroupedIncome,
+  GroupedAsset,
+} from "@/domains/group/types";
 import { runFinancialSimulation } from "@/domains/simulation/financialSimulation";
 
 interface UseFinancialSimulationProps {
-  assets: FinancialAssets;
+  assets: GroupedAsset[];
   expenses?: GroupedExpense[];
   incomes?: GroupedIncome[];
   simulationYears: number;

--- a/src/types/simulation.ts
+++ b/src/types/simulation.ts
@@ -1,5 +1,9 @@
-import { Group, GroupedExpense, GroupedIncome } from "@/domains/group/types";
-import { FinancialAssets } from "@/components/FinancialAssetsForm";
+import {
+  Group,
+  GroupedExpense,
+  GroupedIncome,
+  GroupedAsset,
+} from "@/domains/group/types";
 
 /**
  * シミュレーションのアクションタイプ定数
@@ -17,7 +21,7 @@ export const SIMULATION_ACTION_TYPES = {
   UPSERT_EXPENSES: "UPSERT_EXPENSES",
 
   // 資産関連
-  SET_FINANCIAL_ASSETS: "SET_FINANCIAL_ASSETS",
+  UPSERT_ASSETS: "UPSERT_ASSETS",
 
   // シミュレーション管理
   SAVE_SIMULATION: "SAVE_SIMULATION",
@@ -36,7 +40,7 @@ export interface SimulationCurrentData {
   groups: Group[];
   expenses: GroupedExpense[];
   incomes: GroupedIncome[];
-  financialAssets: FinancialAssets;
+  financialAssets: GroupedAsset[];
 }
 
 /**
@@ -84,8 +88,8 @@ export type SimulationAction =
 
   // 資産関連
   | {
-      type: typeof SIMULATION_ACTION_TYPES.SET_FINANCIAL_ASSETS;
-      payload: FinancialAssets;
+      type: typeof SIMULATION_ACTION_TYPES.UPSERT_ASSETS;
+      payload: { groupId: string; assets: GroupedAsset[] };
     }
 
   // シミュレーション管理


### PR DESCRIPTION
- Add GroupedAsset type with groupId field
- Update SimulationContext to handle UPSERT_ASSETS action
- Refactor useAssetManagement hook to support group-based operations
- Update FinancialAssetsForm to include group selection
- Update FinancialAssetsChart to filter assets by active groups
- Update simulation functions to work with GroupedAsset[]
- Update tests to use new GroupedAsset structure